### PR TITLE
Always manage global version

### DIFF
--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -1,20 +1,15 @@
 # == Class: rbenv::global
 #
-# Set a Ruby version as the global default.
-#
-# TODO: Always manage this file. Use inheritance?
+# Set a Ruby version as the global. Overrides the default which is
+# provided by `Rbenv::Global::Default[]`.
 #
 # === Parameters:
 #
 # [*version*]
-#   Version to use. A matching `Rbenv::Version[]` resource must exist.
-#   Default: system
+#   Version to use. A matching `Rbenv::Version[]` resource must exist. Must
+#   not be `system`.
 #
 # === Examples
-#
-# Use the default system binary:
-#
-# include rbenv::global
 #
 # Use a specific version installed by Puppet:
 #
@@ -25,15 +20,15 @@
 #
 class rbenv::global(
   $version = 'system'
-){
-  $real_require = $version ? {
-    'system' => Class['rbenv'],
-    default  => Rbenv::Version[$version],
+) inherits rbenv::global::default {
+  if ($version == 'system') {
+    fail("${title}: Use rbenv::global::default to set 'system'")
   }
 
-  file { '/usr/lib/rbenv/version':
-    ensure  => present,
+  include rbenv::params
+
+  File[$rbenv::params::global_version] {
     content => "${version}\n",
-    require => $real_require,
+    require +> Rbenv::Version[$version],
   }
 }

--- a/manifests/global/default.pp
+++ b/manifests/global/default.pp
@@ -1,0 +1,19 @@
+# == Class: rbenv::global::default
+#
+# Default the global version to 'system'. This should be included by the
+# main `Rbenv` class. It should not be included directly.
+#
+# Defining the default here, in a separate class, ensures that the file is
+# always managed. Even when `Rbenv::Global` is not used.
+#
+# It can be subsequently overridden with `Rbenv::Global`.
+#
+class rbenv::global::default() {
+  include rbenv::params
+
+  file { $rbenv::params::global_version:
+    ensure  => present,
+    content => "system\n",
+    require => Class['rbenv'],
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@
 #
 class rbenv {
   include rbenv::params
+  include rbenv::global::default
 
   package { 'rbenv':
     ensure => present,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@
 # Common variables referred to by other sub-classes.
 #
 class rbenv::params {
-  $rbenv_root   = '/usr/lib/rbenv'
-  $rbenv_binary = '/usr/bin/rbenv'
+  $rbenv_root     = '/usr/lib/rbenv'
+  $rbenv_binary   = '/usr/bin/rbenv'
+  $global_version = "${rbenv_root}/version"
 }

--- a/spec/classes/rbenv__global__default_spec.rb
+++ b/spec/classes/rbenv__global__default_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'rbenv::global::default' do
+  let(:file_path) { '/usr/lib/rbenv/version' }
+
+  context 'Default to system' do
+    it {
+      should contain_file(file_path).with(
+        :content => "system\n",
+        :require => 'Class[Rbenv]'
+      )
+    }
+  end
+end

--- a/spec/classes/rbenv__global_spec.rb
+++ b/spec/classes/rbenv__global_spec.rb
@@ -3,24 +3,43 @@ require 'spec_helper'
 describe 'rbenv::global' do
   let(:file_path) { '/usr/lib/rbenv/version' }
 
-  context 'Default to system' do
-    it {
-      should contain_file(file_path).with(
-        :content => "system\n",
-        :require => 'Class[Rbenv]'
-      )
-    }
+  context 'when version is set to system' do
+    let(:params) {{
+      :version => 'system',
+    }}
+
+    it do
+      expect {
+        should contain_file(file_path)
+      }.to raise_error(Puppet::Error, /^rbenv::global: Use rbenv::global::default/)
+    end
   end
 
-  context 'Version 1.2.3' do
+  context 'when rbenv::global::default is explicitly included' do
+    let(:pre_condition) { "class { 'rbenv::global::default': }" }
     let(:params) {{
       :version => '1.2.3',
     }}
 
+    it { should include_class('rbenv::global::default') }
+
     it {
       should contain_file(file_path).with(
         :content => "1.2.3\n",
-        :require => 'Rbenv::Version[1.2.3]'
+        :require => ['Class[Rbenv]', 'Rbenv::Version[1.2.3]']
+      )
+    }
+  end
+
+  context 'when rbenv::global::default is not explcitily included' do
+    let(:params) {{
+      :version => '4.5.6',
+    }}
+
+    it {
+      should contain_file(file_path).with(
+        :content => "4.5.6\n",
+        :require => ['Class[Rbenv]', 'Rbenv::Version[4.5.6]']
       )
     }
   end

--- a/spec/classes/rbenv_spec.rb
+++ b/spec/classes/rbenv_spec.rb
@@ -10,4 +10,6 @@ describe 'rbenv' do
       :require => 'Package[rbenv]'
     )
   }
+
+  it { should include_class('rbenv::global::default') }
 end


### PR DESCRIPTION
Ensure that the global version of rbenv is always managed and defaults to
'system' even when `rbenv::global` isn't used.

Achieved by rejigging classes around, so that `rbenv::global::default` is
always included by `rbenv`. This is subsequently inherited and the file
contents overridden by `rbenv::global`.

This is sufficiently more complicated than I would like. But it's
essentially the only way to do it in Puppet.
