### PR TITLE
[#51506059] Query current Bundler version

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -12,8 +12,13 @@
 #
 # === Parameters
 # [*bundler_version*]
-#   Optional parameter that allows to specify the version of bundler to be
-#   installed with the specified version of ruby.
+#   Optional parameter to specify the version of Bundler to be installed for
+#   the given version of Ruby. Accepts pessimistic versioning (~> x.y).
+#
+#   NB: It will NOT attempt to remove any currently installed versions of
+#   Bundler. This means that upgrades will work as expected, but downgrades
+#   will not. The greatest installed version always takes precendence.
+#
 #   Default: >= 0
 #
 # === Examples
@@ -43,12 +48,12 @@ define rbenv::version (
   ]
 
   $cmd_gem     = "${rbenv::params::rbenv_binary} exec gem"
-  $cmd_unless  = "${cmd_gem} list | grep -Pqs '^bundler\s'"
   $cmd_install = "${cmd_gem} install bundler -v '${bundler_version}'"
+  $cmd_unless  = "${cmd_gem} query -i -n bundler -v '${bundler_version}'"
 
   exec { "install bundler for ${version}":
     command     => $cmd_install,
-    unless      => $cmd_unless,
+    unless      => "${env_string} ${cmd_unless}",
     environment => $env_vars,
     notify      => Rbenv::Rehash[$version],
   }

--- a/spec/defines/rbenv__version_spec.rb
+++ b/spec/defines/rbenv__version_spec.rb
@@ -39,7 +39,8 @@ describe 'rbenv::version' do
       context 'bundler_version not set (default)' do
         it {
           should contain_exec(exec_title).with(
-            :command => /gem install bundler -v '>= 0'$/
+            :command => /gem install bundler -v '>= 0'$/,
+            :unless  => /gem query -i -n bundler -v '>= 0'$/
           )
         }
       end
@@ -51,7 +52,8 @@ describe 'rbenv::version' do
 
         it {
           should contain_exec(exec_title).with(
-            :command => /gem install bundler -v '8.9.0'$/
+            :command => /gem install bundler -v '8.9.0'$/,
+            :unless  => /gem query -i -n bundler -v '8.9.0'$/
           )
         }
       end


### PR DESCRIPTION
Be more intelligent about querying the currently installed version of
Bundler. Use `gem query` instead of `gem list|grep`, which allows us to
specifying a version string and returns true/false.

This now means that Bundler will be upgraded if the `bundler_version`
specified is greater than the version currently installed. Which is nice.

Some words about downgrades:

Downgrades are however still not supported. If we specify `bundler_version
=> 2` and then later `bundler_version => 1`, version 1 will be installed but
version 2 will always take precedence. The same will happen if a later
version of Bundler is installed by hand. Added docstrings to warn about
this.

Unfortunately gem doesn't provide an opposite to `gem cleanup`. The only
solution I see to this is to call a Ruby script (of our own) which would
iterate over `Gem::Specification.find_all`, compare versions using
`Gem::Version::Requirement`, and uninstall all but a single version.

Distributing it would be a pain though. It couldn't be a type/provider, as
it would use the RBENV_VERSION that Puppet is running as. It could be a new
gem which extends rubygem's own `Gem::Commands`, but even then it would need
to be installed for every version of Ruby available.

Another alternative:

We could simply query `bundle --version` and `gem install -a bundler` if the
string doesn't match our expectation. However we wouldn't be able to support
loose version requirements, like `>= 0` or `~> 1.2`, which seems like a
major disadvantage.
