### PR TITLE
Remove explicit env var strings from unless cmd

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -40,10 +40,9 @@ define rbenv::version (
     "RBENV_ROOT=${rbenv::params::rbenv_root}",
     "RBENV_VERSION=${version}",
   ]
-  $env_string = inline_template('<%= env_vars.join(" ") -%>')
 
   $cmd_gem     = "${rbenv::params::rbenv_binary} exec gem"
-  $cmd_unless  = "${env_string} ${cmd_gem} list | grep -Pqs '^bundler\s'"
+  $cmd_unless  = "${cmd_gem} list | grep -Pqs '^bundler\s'"
   $cmd_install = $bundler_version ? {
     undef   => "${cmd_gem} install bundler",
     default => "${cmd_gem} install bundler -v ${bundler_version}"
@@ -53,7 +52,6 @@ define rbenv::version (
     command     => $cmd_install,
     unless      => $cmd_unless,
     environment => $env_vars,
-    provider    => 'shell',
     notify      => Rbenv::Rehash[$version],
   }
 

--- a/spec/defines/rbenv__version_spec.rb
+++ b/spec/defines/rbenv__version_spec.rb
@@ -28,12 +28,10 @@ describe 'rbenv::version' do
 
       it 'should set env vars for rbenv' do
         should contain_exec(exec_title).with(
-          :unless      => /^RBENV_ROOT=\/usr\/lib\/rbenv RBENV_VERSION=1.2.3-p456 /,
           :environment => [
             'RBENV_ROOT=/usr/lib/rbenv',
             'RBENV_VERSION=1.2.3-p456',
-          ],
-          :provider    => 'shell'
+          ]
         )
       end
 


### PR DESCRIPTION
It's not necessary to prefix the :unless command with explicit environment
variables. It adopts the settings from :environment in just the same way as
:command. Demonstrated by:

```
➜  puppet git:(master) ✗ b puppet apply
exec { 'should not run':
  command     => '/bin/echo',
  unless      => '/bin/bash -c \'[ "$FOO" == "foo" ]\'',
  environment => "FOO=foo",
}
exec { 'should run':
  command     => '/bin/echo',
  onlyif      => '/bin/bash -c \'[ "$FOO" == "foo" ]\'',
  environment => "FOO=foo",
}
^D
notice: /Stage[main]//Exec[should run]/returns: executed successfully
notice: Finished catalog run in 0.15 seconds
```

Because of this we no longer need to use `provider => shell` either.

I don't recall why my previous test of this made me think it was necessary.
Thanks @philandstuff for the prompt to re-investigate.
## 

Will need rebasing against #4, or vice versa.
