### PR TITLE
[#52225601] Ignore any existing Bundler env vars

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -42,12 +42,13 @@ define rbenv::version (
     require => Class['rbenv'],
   }
 
-  $env_vars   = [
+  $env_vars = [
     "RBENV_ROOT=${rbenv::params::rbenv_root}",
     "RBENV_VERSION=${version}",
   ]
 
-  $cmd_gem     = "${rbenv::params::rbenv_binary} exec gem"
+  $unset_vars  = '/usr/bin/env -uRUBYOPT -uBUNDLE_GEMFILE -uGEM_HOME -uGEM_PATH'
+  $cmd_gem     = "${unset_vars} ${rbenv::params::rbenv_binary} exec gem"
   $cmd_install = "${cmd_gem} install bundler -v '${bundler_version}'"
   $cmd_unless  = "${cmd_gem} query -i -n bundler -v '${bundler_version}'"
 

--- a/spec/defines/rbenv__version_spec.rb
+++ b/spec/defines/rbenv__version_spec.rb
@@ -8,7 +8,7 @@ describe 'rbenv::version' do
   context 'Version 1.2.3-p456' do
     let(:title) { '1.2.3-p456' }
     let(:exec_title) { 'install bundler for 1.2.3-p456' }
-    let(:cmd_prefix) { /^\/usr\/bin\/rbenv exec gem/ }
+    let(:cmd_prefix) { /^\/usr\/bin\/env -uRUBYOPT -uBUNDLE_GEMFILE -uGEM_HOME -uGEM_PATH \/usr\/bin\/rbenv exec gem/ }
 
     context 'ruby version' do
       it {
@@ -24,7 +24,7 @@ describe 'rbenv::version' do
       it { should contain_exec(exec_title).with_notify('Rbenv::Rehash[1.2.3-p456]') }
     end
 
-    context 'bunder' do
+    context 'bundler' do
       it 'should set env vars for rbenv' do
         should contain_exec(exec_title).with(
           :environment => [


### PR DESCRIPTION
Ignore any existing Bundler environment variables when querying the
currently installed versions of Bundler. This is required when Puppet itself
is run under Bundler - in which case you would get the version of Bundler
that it was originally instantiated with.
## 

/cc @philandstuff 
