### PR TITLE
Allow installation of bundler even when puppet is within rbenv

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,5 @@
 fixtures:
+  repositories:
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     rbenv: "#{source_dir}"

--- a/Modulefile
+++ b/Modulefile
@@ -5,3 +5,5 @@ author        'Government Digital Service'
 license       'MIT'
 summary       'System wide rbenv'
 project_page  'https://github.com/gds-operations/puppet-rbenv'
+
+dependency 'puppetlabs/stdlib', '>= 3.0.0'

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -42,7 +42,10 @@ define rbenv::version (
     require => Class['rbenv'],
   }
 
+  $path_munged = join(reject(split($::path,':'),'rbenv/versions'),':')
+
   $env_vars = [
+    "PATH=${path_munged}",
     "RBENV_ROOT=${rbenv::params::rbenv_root}",
     "RBENV_VERSION=${version}",
   ]

--- a/spec/defines/rbenv__version_spec.rb
+++ b/spec/defines/rbenv__version_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'rbenv::version' do
   let(:facts) {{
     :osfamily => 'Debian',
+    :path     => '/usr/lib/rbenv/versions/1.9.3/bin:/usr/lib/rbenv/libexec:/usr/lib/rbenv/shims:/usr/sbin:/usr/bin:/sbin:/bin',
   }}
 
   context 'Version 1.2.3-p456' do
@@ -28,6 +29,7 @@ describe 'rbenv::version' do
       it 'should set env vars for rbenv' do
         should contain_exec(exec_title).with(
           :environment => [
+            'PATH=/usr/lib/rbenv/libexec:/usr/lib/rbenv/shims:/usr/sbin:/usr/bin:/sbin:/bin',
             'RBENV_ROOT=/usr/lib/rbenv',
             'RBENV_VERSION=1.2.3-p456',
           ]


### PR DESCRIPTION
If puppet is being run from within rbenv, then it will have been set
the PATH variable to have the configured ruby version first in the
PATH. This means that even if you change the RBENV_VERSION variable,
gem commands will use the current rbenv-configured ruby rather than
the new one, and rbenv::version will install bundler into puppet's own
rbenv ruby, rather than the one it is installing in rbenv::version.

We fix this by scrubbing the PATH of rbenv ruby versions when running
gem commands.

Fixes #7.
