### PR TITLE
Fixing typo of `rbenv` in comment

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 # the following for all new shell sessions:
 #
 # - Set `RBENT_ROOT` to a common system path.
-# - Run `rvenv init`.
+# - Run `rbenv init`.
 #
 # === Parameters:
 #


### PR DESCRIPTION
Noticed this typo in the comments while reading through the manifests.

Thanks for sharing this module :+1: 
