### PR TITLE
Install latest versions of rbenv-ruby packages.

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -38,6 +38,7 @@ define rbenv::version (
   $package_name = "rbenv-ruby-${version}"
 
   package { $package_name:
+    ensure  => latest,
     notify  => Exec["install bundler for ${version}"],
     require => Class['rbenv'],
   }

--- a/spec/defines/rbenv__version_spec.rb
+++ b/spec/defines/rbenv__version_spec.rb
@@ -14,6 +14,7 @@ describe 'rbenv::version' do
     context 'ruby version' do
       it {
         should contain_package('rbenv-ruby-1.2.3-p456').with(
+          :ensure  => "latest",
           :notify  => "Exec[#{exec_title}]",
           :require => 'Class[Rbenv]'
         )


### PR DESCRIPTION
This will enable us to roll out fixes for a specific ruby version by
uploading a newer package.
