### PR TITLE
Revert "Allow installation of bundler even when puppet is within rbenv"

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,3 @@
 fixtures:
-  repositories:
-    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     rbenv: "#{source_dir}"

--- a/Modulefile
+++ b/Modulefile
@@ -5,5 +5,3 @@ author        'Government Digital Service'
 license       'MIT'
 summary       'System wide rbenv'
 project_page  'https://github.com/gds-operations/puppet-rbenv'
-
-dependency 'puppetlabs/stdlib', '>= 3.0.0'

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -43,10 +43,7 @@ define rbenv::version (
     require => Class['rbenv'],
   }
 
-  $path_munged = join(reject(split($::path,':'),'rbenv/versions'),':')
-
   $env_vars = [
-    "PATH=${path_munged}",
     "RBENV_ROOT=${rbenv::params::rbenv_root}",
     "RBENV_VERSION=${version}",
   ]

--- a/spec/defines/rbenv__version_spec.rb
+++ b/spec/defines/rbenv__version_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe 'rbenv::version' do
   let(:facts) {{
     :osfamily => 'Debian',
-    :path     => '/usr/lib/rbenv/versions/1.9.3/bin:/usr/lib/rbenv/libexec:/usr/lib/rbenv/shims:/usr/sbin:/usr/bin:/sbin:/bin',
   }}
 
   context 'Version 1.2.3-p456' do
@@ -30,7 +29,6 @@ describe 'rbenv::version' do
       it 'should set env vars for rbenv' do
         should contain_exec(exec_title).with(
           :environment => [
-            'PATH=/usr/lib/rbenv/libexec:/usr/lib/rbenv/shims:/usr/sbin:/usr/bin:/sbin:/bin',
             'RBENV_ROOT=/usr/lib/rbenv',
             'RBENV_VERSION=1.2.3-p456',
           ]


### PR DESCRIPTION
This fix was not necessary because `rbenv exec` [prepends an entry to the path](https://github.com/sstephenson/rbenv/blob/master/libexec/rbenv-exec#L45) that will take precedence over the entry that's already there.

Additionally, passing `PATH` to an `exec` resource like this triggers puppet warnings, which leads to lots of noise in puppet runs.

This reverts commit 5a542313e956a48ef708cae7ae54d005a0fb66a1 (PR #8).  As mentioned in that PR, we've been using a version prior to this fix up until now without issue, so I'm confident that this is safe to revert.
