### PR TITLE
Migrate from Modulefile to metadata.json

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,7 +1,0 @@
-name          'gdsoperations-rbenv'
-version       '1.2.0'
-source        'https://github.com/gds-operations/puppet-rbenv'
-author        'Government Digital Service'
-license       'MIT'
-summary       'System wide rbenv'
-project_page  'https://github.com/gds-operations/puppet-rbenv'

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name":         "gdsoperations-rbenv",
+  "version":      "1.2.0",
+  "author":       "Government Digital Service",
+  "license":      "MIT",
+  "summary":      "System wide rbenv",
+  "source":       "https://github.com/gds-operations/puppet-rbenv",
+  "project_page": "https://github.com/gds-operations/puppet-rbenv",
+  "issues_url":   "https://github.com/gds-operations/puppet-rbenv/issues",
+  "tags":         ["ruby", "rbenv"],
+  "operatingsystem_support": [
+    {
+    "operatingsystem": "Ubuntu",
+    "operatingsystemrelease": ["12.04", "14.04"]
+    }
+  ],
+  "dependencies": [
+  ]
+}


### PR DESCRIPTION
Modulefile is deprecated and metadata.json
is what the forge now expects.