### PR TITLE
Be explicit about version numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
 env:
   matrix:
     - PUPPET_VERSION="~> 3.8.5"
-    - PUPPET_VERSION="~> 4.3.2"
+    - PUPPET_VERSION="~> 4.8.0"
 matrix:
   exclude:
     - rvm: 2.2.0

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,12 @@ source 'https://rubygems.org'
 # Versions can be overridden with environment variables for matrix testing.
 # Travis will remove Gemfile.lock before installing deps.
 
-gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.2.0'
+gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8.0'
 
 gem 'rake'
-gem 'puppet-lint', '1.1.0'
+gem 'puppet-lint', '2.1.0'
 gem 'rspec-puppet', '2.2.0'
 gem 'rspec-system-puppet'
-gem 'puppetlabs_spec_helper', '1.0.1'
+gem 'puppetlabs_spec_helper', '2.1.0'
 gem 'puppet-syntax'
+gem 'nokogiri', '~> 1.6.0'


### PR DESCRIPTION
The travis tests were failing when the versions were not explicit
so we're being stricter and ensuring the versions we specify work
together.