### PR TITLE
Dealing With Darwin (MacOS)

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -69,11 +69,20 @@ define rbenv::version (
 
     rbenv::rehash { $version: }
 
-  } elsif $ensure == 'absent' {
+  } elsif $ensure == 'absent' and $::operatingsystem != 'Darwin' {
 
     package { $package_name:
       ensure => purged,
     }
+
+    # Cleanup bundler and any other gems (installed by the above exec)
+    file { "${rbenv::params::rbenv_root}/versions/${version}":
+      ensure  => absent,
+      force   => true,
+      require => Package[$package_name],
+    }
+
+  } elsif $ensure == 'absent' and $::operatingsystem == 'Darwin' {
 
     # Cleanup bundler and any other gems (installed by the above exec)
     file { "${rbenv::params::rbenv_root}/versions/${version}":


### PR DESCRIPTION
The package provider does not support anything but install for MacOS.  MacOS does not have a native uninstall function either.  Mac experts suggest removing the files associated with the package :-(

See Apple provider:

https://github.com/puppetlabs/puppet/blob/3.1.x/lib/puppet/provider/package/apple.rb

https://docs.puppet.com/puppet/3.8/type.html#package-provider-apple

See card: https://trello.com/c/weIueJbe