### PR TITLE
puppet-lint doesn't like arrows in the old form.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,11 +20,13 @@ class rbenv(
 
   package { 'rbenv':
     ensure => present,
-  } ->
+  }
+
   file { '/etc/profile.d/rbenv.sh':
     ensure  => present,
     mode    => '0755',
     content => template('rbenv/etc/profile.d/rbenv.sh.erb'),
-  } ->
-  class { 'rbenv::global': }
+    require => Package['rbenv'],
+  }
+  -> class { 'rbenv::global': }
 }


### PR DESCRIPTION
Also convert one of the arrows to a require as otherwise
it makes the file resource harder to read due to the
awkward indentation.