### PR TITLE
[DONOTMERGE] Use resources we 'require'

### DIFF
--- a/manifests/alias.pp
+++ b/manifests/alias.pp
@@ -24,6 +24,8 @@ define rbenv::alias(
   $version = $title
   $versions_path = '/usr/lib/rbenv/versions'
 
+  rbenv::version { $to_version: }
+
   file { "${versions_path}/${version}":
     ensure  => link,
     target  => $to_version,

--- a/manifests/global.pp
+++ b/manifests/global.pp
@@ -14,6 +14,9 @@ class rbenv::global {
     'system' => undef,
     default  => Rbenv::Version[$version],
   }
+
+  rbenv::version { $version: }
+
   file { $rbenv::params::global_version:
     ensure  => present,
     content => "${version}\n",

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -38,6 +38,7 @@ define rbenv::version (
   $ensure = 'present',
   $bundler_version = '>= 0'
 ) {
+  include rbenv
   include rbenv::params
 
   $version = $title


### PR DESCRIPTION
If you use them in requires before using them then puppet throws
Could not find resource 'Rbenv::Version[1.2.3]' in parameter 'require'
warnings.