### PR TITLE
Save time and inodes by not installing gem documentation by default

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -69,6 +69,15 @@ define rbenv::version (
 
     rbenv::rehash { $version: }
 
+    # Save time and inodes by not installing gem documentation by default.
+    file { "${rbenv::params::rbenv_root}/versions/${version}/etc":
+      ensure => directory,
+    }
+    file { "${rbenv::params::rbenv_root}/versions/${version}/etc/gemrc":
+      ensure  => present,
+      content => "gem: --no-document --no-rdoc --no-ri\n",
+    }
+
   } elsif $ensure == 'absent' {
 
     package { $package_name:

--- a/spec/defines/rbenv__version_spec.rb
+++ b/spec/defines/rbenv__version_spec.rb
@@ -18,6 +18,17 @@ describe 'rbenv::version' do
           :require => 'Class[Rbenv]'
         )
       }
+
+      it {
+        should contain_file('/usr/lib/rbenv/versions/1.2.3-p456/etc').with(
+          :ensure => "directory",
+        )
+
+        should contain_file('/usr/lib/rbenv/versions/1.2.3-p456/etc/gemrc').with(
+          :ensure => "present",
+          :content => "gem: --no-document --no-rdoc --no-ri\n"
+        )
+      }
     end
 
     context 'rehash' do


### PR DESCRIPTION
https://trello.com/c/63S3WW81/404-dont-install-documentation-for-gems-on-ci

In particular, on ci-master-1.ci.integration,
we’re seeing 40% of the inodes of the disk
consumed by gem documentation.

We need to use both ‘--no-document’ and
‘--no-rdoc --no-ri’ so it works with older
versions of Ruby as well as new.

https://forge.puppet.com/gdsoperations/rbenv