### PR TITLE
Use notify based approach for gem documentation preference

### DIFF
--- a/spec/defines/rbenv__version_spec.rb
+++ b/spec/defines/rbenv__version_spec.rb
@@ -8,19 +8,20 @@ describe 'rbenv::version' do
   context 'Version 1.2.3-p456' do
     let(:title) { '1.2.3-p456' }
     let(:exec_title) { 'install bundler for 1.2.3-p456' }
+    let(:rbenv_etc) { '/usr/lib/rbenv/versions/1.2.3-p456/etc' }
     let(:cmd_prefix) { /^\/usr\/bin\/env -uRUBYOPT -uBUNDLE_GEMFILE -uGEM_HOME -uGEM_PATH \/usr\/bin\/rbenv exec gem/ }
 
     context 'ruby version' do
       it {
         should contain_package('rbenv-ruby-1.2.3-p456').with(
           :ensure  => "latest",
-          :notify  => "Exec[#{exec_title}]",
+          :notify  => "File[#{rbenv_etc}]",
           :require => 'Class[Rbenv]'
         )
       }
 
       it {
-        should contain_file('/usr/lib/rbenv/versions/1.2.3-p456/etc/gemrc').with(
+        should contain_file("#{rbenv_etc}/gemrc").with(
           :ensure => "absent",
           :force => true
         )
@@ -32,11 +33,11 @@ describe 'rbenv::version' do
         }}
 
         it {
-          should contain_file('/usr/lib/rbenv/versions/1.2.3-p456/etc').with(
+          should contain_file(rbenv_etc).with(
             :ensure => "directory",
           )
 
-          should contain_file('/usr/lib/rbenv/versions/1.2.3-p456/etc/gemrc').with(
+          should contain_file("#{rbenv_etc}/gemrc").with(
             :ensure => "present",
             :content => "gem: --no-document --no-rdoc --no-ri\n"
           )


### PR DESCRIPTION
This changes the approach used to install Ruby version as currently
everytime a new Ruby version is installed an error occurs and then only
succeeds on the subsequent puppet run.

As far as I understand the issue with the existing approach is that
puppet doesn't run everything in a procedural order instead it uses the
script to decide what to do and then determines the order. Thus we were
getting errors that a directory wasn't available:

```
Error: Cannot create /usr/lib/rbenv/versions/2.5.1/etc; parent directory /usr/lib/rbenv/versions/2.5.1 does not exist
Error: /Stage[main]/Govuk_rbenv::All/Rbenv::Version[2.5.1]/File[/usr/lib/rbenv/versions/2.5.1/etc]/ensure: change from absent to directory failed: Cannot create /usr/lib/rbenv/versions/2.5.1/etc; parent directory /usr/lib/rbenv/versions/2.5.1 does not exist
Notice: /Stage[main]/Govuk_rbenv::All/Rbenv::Version[2.5.1]/File[/usr/lib/rbenv/versions/2.5.1/etc/gemrc]: Dependency File[/usr/lib/rbenv/versions/2.5.1/etc] has failures: true
Warning: /Stage[main]/Govuk_rbenv::All/Rbenv::Version[2.5.1]/File[/usr/lib/rbenv/versions/2.5.1/etc/gemrc]: Skipping because of failed dependencies
```

This instead changes the process to use puppet notify so that
these actions occur in a determined order. This allows the parent
directory to exist prior to setting up the configuration of gem
documentation.