### PR TITLE
Bump to version 1.3.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2018-04-12 Release 1.3.1
+- Fix puppet error that occurs first time this is run for a new ruby version.
+
 2018-01-08 Release 1.3.0
 - Add an option not to install gem documentation (default: false, install gem
   documentation).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":         "gdsoperations-rbenv",
-  "version":      "1.3.0",
+  "version":      "1.3.1",
   "author":       "Government Digital Service",
   "license":      "MIT",
   "summary":      "System wide rbenv",


### PR DESCRIPTION
Fix puppet error that occurs first time this is run for a new ruby version.